### PR TITLE
Change @vendor/bower to @bower

### DIFF
--- a/WebUIPopoverAsset.php
+++ b/WebUIPopoverAsset.php
@@ -18,7 +18,7 @@ use yii\web\AssetBundle;
 
 class WebUIPopoverAsset extends AssetBundle
 {
-    public $sourcePath = '@vendor/bower/webui-popover/dist/';
+    public $sourcePath = '@bower/webui-popover/dist/';
 
     public $js = [
         'jquery.webui-popover.js'


### PR DESCRIPTION
Some setups have the bower directory as /vender/bower-asset.
Using the @bower alias will get the correct path based on the current config rather than assuming it to be /vendor/bower